### PR TITLE
Make switching cameras work

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,7 +243,7 @@ startAndStop.addEventListener('click', () => {
 });
 
 changeCamera.addEventListener('click', () => {
-    	change_camera++;
+    	currentCamera++;
 		stopCamera();
 		startCamera();
 });


### PR DESCRIPTION
This patch makes switching cameras work.

The problem in your previous code was that `findIdVideo()` returned an empty list. The reason is that  `navigator.mediaDevices.enumerateDevices()` returns a promise, which is still in a pending state when `findIdVideo()` reaches its return statement. I changed `findIdVideo()` to return a promise too. The camera list is now saved into a global variable when that promise gets resolved.

Other solutions would be more elegant, but I just wanted to make the minimal change possible to your code.